### PR TITLE
Added mod options and tweaked XP rate calculations + refactor

### DIFF
--- a/NM_ExamineCorpsesPLUS/media/lua/server/ExamineCorpsePLUS.lua
+++ b/NM_ExamineCorpsesPLUS/media/lua/server/ExamineCorpsePLUS.lua
@@ -1,10 +1,65 @@
+local lvlcurveXPValues = {20,20,20,20,25,50,60,60,80,80}; -- XP given depending on current level of firstaid
+local xpRequiredPerLevel = {75,150,300,750,1500,3000,4500,6000,7500,9000}; -- XP needed for next level
+
+local modSettings = ExamineCorpses_global.SETTINGS
+local ExaminationsRequiredFactorSettings = {5,2,1,0.5}; -- must match up to the array from mod settings
+
 function ExamineCorpse(items, result, player)
+	local action_type = "examine"
+	AwardExamineXP(items, result, player, action_type);
+	AffectPlayerMood(items, result, player, action_type);
+end
+
+function ExamineCorpseSurgically(items, result, player)
+	local action_type = "examine_surgically"
+	AwardExamineXP(items, result, player, action_type);
+	AffectPlayerMood(items, result, player, action_type);
+end
+
+function AwardExamineXP(items, result, player, type_of_action)
+	
+	-- Get Base XP reward for current First Aid level and mod settings
+	local actionType = type_of_action;
+	local ExaminationsRequiredFactor = tonumber(ExaminationsRequiredFactorSettings[tonumber(modSettings.options.dropdown1)]);
+
+	local XPAward = tonumber(lvlcurveXPValues[tonumber(player:getPerkLevel(Perks.Doctor)) + 1]);
+	XPAward = XPAward / ExaminationsRequiredFactor;
+	-- surgical examinations earn more XP (double)
+	if type_of_action == "examine_surgically" then
+		XPAward = XPAward * 2;
+	end
+
+	-- Apply Skillbook multipliers to XP award
+	XPAward = XPAward * (1 + player:getXp():getMultiplier(Perks.Doctor)); -- Skillbook multiplier is additive so multiplier of 3 means times 4
+
+	-- Get maximum XP to give for current First Aid level and mod settings so we force a minimum number of examinations per level of firstaid earned
+	local xpRequiredForLevel = tonumber(xpRequiredPerLevel[tonumber(player:getPerkLevel(Perks.Doctor) + 1)]);
+	local clampXP = xpRequiredForLevel / (10 * ExaminationsRequiredFactor);
+
+	-- Adjust Clamp XP to make up for profression / trait perk bonuses
+	local perkBoostLevel = player:getXp():getPerkBoost(Perks.Doctor)
+	if perkBoostLevel == 0 then
+		clampXP = clampXP * 4; -- 25% XP gain, so clamp should be 4 times higher
+	elseif perkBoostLevel == 1 then
+		clampXP = clampXP * 1; -- 100% XP gain, so clamp is already the right value
+	elseif perkBoostLevel == 2 then
+		clampXP = clampXP * 0.8; -- 125% XP gain, so clamp should be 80%
+	elseif perkBoostLevel == 3 then
+		clampXP = clampXP * 0.66; -- 150% XP gain, so clamp should be 66%
+	end
+
+	-- XP Award to be no more than clampXP
+	XPAward = math.min(XPAward, clampXP);
+
+	-- Give XP to player -- This will not apply skillbook modifier but it does apply the Perk modifier hence why we adjusted clamping
+	player:getXp():AddXPNoMultiplier(Perks.Doctor, XPAward);
+
+end
+
+function AffectPlayerMood(items, result, player, type_of_action)
 	local sickMult = 1.0;
 	local happyMult = 1.0;
 	local doctorSkillMult = math.max(player:getPerkLevel(Perks.Doctor), 1.0);
-	
-	happyMult = happyMult - (doctorSkillMult / 15);
-	sickMult = sickMult - (doctorSkillMult / 20);
 
 	if player:HasTrait("Desensitized") then
 		happyMult = 0.8;
@@ -16,53 +71,28 @@ function ExamineCorpse(items, result, player)
 		sickMult = 1.2;	
 	end
 
-	player:getXp():AddXP(Perks.Doctor, 9 * doctorSkillMult); -- xp is getting divided by 4 for some reason
-	
-	local bodyDamage = player:getBodyDamage();
-	if bodyDamage:getFoodSicknessLevel() + 60 * sickMult >= 90 then
-        bodyDamage:setFoodSicknessLevel(90);
-    else
-        bodyDamage:setFoodSicknessLevel(bodyDamage:getFoodSicknessLevel() + 60 * sickMult);
-    end
+	local sickValue = 60;
+	local happyValue = 35;
 
-	if bodyDamage:getUnhappynessLevel() + 35 * happyMult >= 100 then
-        bodyDamage:setUnhappynessLevel(100);
-    else
-        bodyDamage:setUnhappynessLevel(bodyDamage:getUnhappynessLevel() + 35 * happyMult);
-    end
+	if type_of_action == 'examine_surgically' then
+		sickValue = 25;
+		happyValue = 15;
+	end
 
-end
-
-function ExamineCorpseSurgically(items, result, player)
-	local sickMult = 1.0;
-	local happyMult = 1.0;
-	local doctorSkillMult = math.max(player:getPerkLevel(Perks.Doctor), 1.0);
-	
 	happyMult = happyMult - (doctorSkillMult / 15);
 	sickMult = sickMult - (doctorSkillMult / 20);
 	
-	if player:HasTrait("Desensitized") then
-		happyMult = 0.55;
-		sickMult = 0.55;
-	end
-
-	if player:HasTrait("Hemophobic") then
-		happyMult = 1.1;
-		sickMult = 1.1;
-	end
-
-	player:getXp():AddXP(Perks.Doctor, 20 * doctorSkillMult);
-
 	local bodyDamage = player:getBodyDamage();
-	if bodyDamage:getFoodSicknessLevel() + 25 * sickMult >= 90 then
+	if bodyDamage:getFoodSicknessLevel() + (sickValue * sickMult) >= 90 then
         bodyDamage:setFoodSicknessLevel(90);
     else
-        bodyDamage:setFoodSicknessLevel(bodyDamage:getFoodSicknessLevel() + 25 * sickMult);
+        bodyDamage:setFoodSicknessLevel(bodyDamage:getFoodSicknessLevel() + (sickValue * sickMult));
     end
 
-	if bodyDamage:getUnhappynessLevel() + 15 * happyMult >= 100 then
+	if bodyDamage:getUnhappynessLevel() + (happyValue * happyMult) >= 100 then
         bodyDamage:setUnhappynessLevel(100);
     else
-        bodyDamage:setUnhappynessLevel(bodyDamage:getUnhappynessLevel() + 15 * happyMult);
+        bodyDamage:setUnhappynessLevel(bodyDamage:getUnhappynessLevel() + (happyValue * happyMult));
     end
+
 end

--- a/NM_ExamineCorpsesPLUS/media/lua/shared/ExamineCorpses_ModOptions.lua
+++ b/NM_ExamineCorpsesPLUS/media/lua/shared/ExamineCorpses_ModOptions.lua
@@ -1,0 +1,26 @@
+--Default options.
+local SETTINGS = { 
+	options = {
+		dropdown1 = 3,
+	},
+	names= {
+		dropdown1 = "XP Gain Rate",
+	},
+	mod_id = "ExamineCorpsesPLUS",
+	mod_shortname = "Examine Corpses"
+}
+
+-- Connecting the options to the menu, so user can change them.
+if ModOptions and ModOptions.getInstance then
+	local settings = ModOptions:getInstance(SETTINGS)
+	local drop1 = settings:getData("dropdown1")
+	drop1[1] = "Very Slow"
+	drop1[2] = "Slow"
+	drop1[3] = "Normal"
+	drop1[4] = "Fast"
+	drop1.tooltip = "Tweaks XP reward to require an average number of examinations per level gain (Very Slow = 50, Slow = 20, normal = 10, fast = 5)"
+
+end
+
+ExamineCorpses_global = {}
+ExamineCorpses_global.SETTINGS = SETTINGS


### PR DESCRIPTION
**Changes:**
- Changed XP rate calculations curve with respect to the level of first aid (improved scaling)
- Added clamping to enforce a minimum number of corpse examinations to reach new level of first aid.
- Added Mod options for a setting the number of corpse examinations required per level up 
( very slow: 50 corpses, slow: 20 corpses, normal: 10 corpses, fast: 5 corpses )
- Refactor of mood and XP impact code

**Limitations:** Mod options do not work currently with dedicated MP servers due to lack of required functionality in the Mod Options mod, they will be set to "normal" by default.
